### PR TITLE
Introduce pod-file pane, a fuzzy-finder style pane for the files in the current pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Without `ember-tabs` you end up with a bunch of tabs all named `template.hbs` or
 
 ![screenshot](http://i.imgur.com/PAsMJQP.png)
 
+### Pod fuzzy find
+
+Pressing `cmd+shift+m` reveals a fuzzy finder window on the current pods directory, to make it easy to switch between template/component/route/styles etc.
+
+![](http://i.imgur.com/5zvc0Js.png)
+
 ## Installation
 
 Search for "ember-tabs" in `Install packages`. You can also find it in the Atom package index:

--- a/keymaps/ember-tabs.cson
+++ b/keymaps/ember-tabs.cson
@@ -8,4 +8,4 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
 'atom-workspace':
-  'ctrl-alt-o': 'ember-tabs:toggle'
+  'cmd-shift-m': 'ember-tabs:open-file-pane'

--- a/lib/ember-tabs.coffee
+++ b/lib/ember-tabs.coffee
@@ -1,17 +1,41 @@
+{CompositeDisposable} = require 'atom'
+
 module.exports =
-	activate: (state) ->
-		EmberPodsProject = require './ember-pods-project'
-		TabWatcher = require './tab-watcher'
+  activate: (state) ->
+    EmberPodsProject = require './ember-pods-project'
+    TabWatcher = require './tab-watcher'
+    PodFilePane = require './pod-file-pane'
 
-		for path in atom.project.getPaths()
-			project = new EmberPodsProject path
+    @podFilePane = new PodFilePane()
 
-			project.isEmberPodsProject (yesOrNo) =>
-				if yesOrNo
-					@tabWatcher = new TabWatcher() unless @tabWatcher
-				else
-					console.log "[ember-tabs] Did not detect ember project with pods enabled."
+    # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
+    @subscriptions = new CompositeDisposable
 
-	deactivate: ->
+    # Register command that toggles this view
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'ember-tabs:open-file-pane': => @openFilePane()
 
-	serialize: ->
+    @projects = []
+
+    for path in atom.project.getPaths()
+      project = new EmberPodsProject path
+      @projects.push project
+
+      project.isEmberPodsProject (yesOrNo) =>
+        if yesOrNo
+          @tabWatcher = new TabWatcher() unless @tabWatcher
+        else
+          console.log "[ember-tabs] Did not detect ember project with pods enabled."
+
+  deactivate: ->
+    @subscriptions.dispose()
+    @podFilePane.destroy()
+
+  serialize: ->
+
+  openFilePane: ->
+    activePath = atom.workspace.getActiveTextEditor().getPath()
+
+    # TODO: Move logic to check if path is a pod somewhere, since it's duplicated in `ember-pods-project`
+    if activePath.indexOf("/app/") != -1
+      @podFilePane.toggle atom.workspace.getActiveTextEditor().getPath()

--- a/lib/pod-file-pane.coffee
+++ b/lib/pod-file-pane.coffee
@@ -13,7 +13,7 @@ class PodFilePane extends SelectListView
    @panel.hide()
 
  viewForItem: (item) ->
-   "<li>#{path.basename(item)}</li>"
+   "<li><span>#{path.basename(path.dirname(item))}/</span><strong>#{path.basename(item)}</strong></li>"
 
  confirmed: (item) ->
    atom.workspace.open(item)

--- a/lib/pod-file-pane.coffee
+++ b/lib/pod-file-pane.coffee
@@ -1,0 +1,40 @@
+{SelectListView} = require 'atom-space-pen-views'
+
+path = require 'path'
+fs = require 'fs'
+
+module.exports =
+class PodFilePane extends SelectListView
+ initialize: ->
+   super
+   @addClass('overlay from-top')
+   @setItems([])
+   @panel ?= atom.workspace.addModalPanel(item: this)
+   @panel.hide()
+
+ viewForItem: (item) ->
+   "<li>#{path.basename(item)}</li>"
+
+ confirmed: (item) ->
+   atom.workspace.open(item)
+
+ cancelled: ->
+   @panel.hide()
+
+  getElement: ->
+    @element
+
+  toggle: (onPath) =>
+    @loadItemsForPath(onPath)
+
+    if @panel.isVisible()
+      @panel.hide()
+    else
+      @panel.show()
+      @focusFilterEditor()
+
+  loadItemsForPath: (onPath) =>
+    componentFolder = path.dirname(onPath)
+
+    fs.readdir componentFolder, (err, files) =>
+      @setItems files.map((file) => "#{componentFolder}/#{file}")

--- a/package.json
+++ b/package.json
@@ -13,5 +13,7 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "atom-space-pen-views": "^2.1.0"
+  }
 }


### PR DESCRIPTION
Currently set to `cmd+shift+m`, opens a fuzzy-finder window on the current text editor's pod structure. Makes it easy to switch between files in a pod.
