### PR TITLE
Allow config for usePods

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,0 +1,7 @@
+module.exports = {
+  ignorePods:
+    description: 'Ignore usePods Config'
+    type: 'boolean'
+    default: false
+    order: 1
+}

--- a/lib/ember-pods-project.coffee
+++ b/lib/ember-pods-project.coffee
@@ -11,6 +11,9 @@ class EmberPodsProject
   isEmberPodsProject: (callback) =>
     @checkDotEmberCliFile callback
 
+  getIgnorePods: () =>
+    return atom.config.get('ember-tabs.ignorePods')
+
   checkDotEmberCliFile: (callback) =>
     dotEmberCliFile = "#{@rootPath}/.ember-cli"
 
@@ -26,7 +29,7 @@ class EmberPodsProject
             callback(true)
           else
             console.log "[ember-tabs] Trying to parse the contents"
-            
+
             try
               @emberCliSettings = JSON.parse(stripeJsonComments(contents.toString()))
               console.log "[ember-tabs] Parsing worked great."
@@ -35,8 +38,10 @@ class EmberPodsProject
               callback(true)
               return
 
+            console.log "[ember-tabs] Everying read fine. Ignore usePods Config: #{@getIgnorePods()}"
             console.log "[ember-tabs] Everying read fine. Settings: #{@emberCliSettings["usePods"]}"
-            callback @emberCliSettings["usePods"]
+            activated = @getIgnorePods() || @emberCliSettings["usePods"]
+            callback activated
       else
         console.log "[ember-tabs] .ember-cli did not exist."
         callback(false)

--- a/lib/ember-tabs.coffee
+++ b/lib/ember-tabs.coffee
@@ -1,6 +1,8 @@
 {CompositeDisposable} = require 'atom'
 
 module.exports =
+  config: require('./config.coffee')
+
   tabWatchers: null
 
   activate: (state) ->


### PR DESCRIPTION
This allows users to ignore the `usePods` setting from `.ember-cli` folder.

The use case for this is for projects that mix pods and not. While not advised to mix the two file styles, there should be a way to always opt in for ember projects.
