### PR TITLE
Normalize backslashes to forward slashes for windows support

### DIFF
--- a/lib/tab-watcher.coffee
+++ b/lib/tab-watcher.coffee
@@ -55,7 +55,7 @@ class TabWatcher
     item.emitter.emit "did-change-title", item.getTitle()
 
   getEmberPodName: (item) =>
-    filePath = item.getPath()
+    filePath = item.getPath().replace(/\\/g, '/')
     pieces = filePath?.split("/")
 
     return false if !pieces || !pieces.length


### PR DESCRIPTION
Fixes #8

The regex\string-split for file paths was failing on Windows since Atom's `getPath()` (rather-annoyingly) returns paths with backslashes when running in Windows.

Note that I only made the replacement in `tab-watcher.coffee`. I didn't touch `ember-tabs.coffee` since it didn't need it (file I/O works fine with either slash type), though lemme know if I should change it both places for consistency and I'll update the PR.
